### PR TITLE
Syntaxerror in JSON-Output

### DIFF
--- a/src_framework/node/node.cpp
+++ b/src_framework/node/node.cpp
@@ -225,7 +225,7 @@ void CNode::setProgress(qint8 percentage)
              << "{\"status\":" << "{\"node\":"
              << getConfig().getName() << ", "
              << "\"progress\":" << percentage
-             << "}";
+             << "}" << "}";
     }
 }
 


### PR DESCRIPTION
Missing "}" at the end of status output
